### PR TITLE
removed z-index and changed order of elements on AgendaGroup

### DIFF
--- a/frontend/src/components/MeetingView/AgendaView/AgendaGroup.scss
+++ b/frontend/src/components/MeetingView/AgendaView/AgendaGroup.scss
@@ -40,7 +40,6 @@
             fill: $darkBlue;
             position: relative;
             bottom: 0.22em;
-            z-index: 1;
           }
           .expansionIconStatus {
             position: absolute;

--- a/frontend/src/components/MeetingView/AgendaView/AgendaGroups.jsx
+++ b/frontend/src/components/MeetingView/AgendaView/AgendaGroups.jsx
@@ -183,10 +183,10 @@ function AgendaGroupHeader({
               </div>
             </div>
             <div className="group-icon">
+              <span className="expansionIconStatus"><StatusInProgress className={buildIconClass(active, next, completed)} /></span>
               <span className="expansionIcon">
                 {!expanded ? <AddIcon /> : <RemoveIcon />}
               </span>
-              <span className="expansionIconStatus"><StatusInProgress className={buildIconClass(active, next, completed)} /></span>
             </div>
           </div>
         </AccordionItemButton>


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
**bug fix**

- Describe what changes are being made
**removed z-index from expansionIcon class, swapped expansionIcon and expansionIconStatus element order**

- Describe why these changes are being made
**z-index was causing group icons to display on top of UpdateItemTimeModal**

- List the use cases and edge cases relevant to this PR
**N/A**

- Describe how errors will be handled. How will we know if this code breaks in production
**N/A**

- Describe any external libraries/dependencies added or removed in this PR
**N/A**

- Describe any security risks are there regarding this change
**N/A**

- Describe how you tested these changes
**Viewed in browser, checked functionality to verify no issues were seen**

- Link to relevant external documentation
**N/A**


--------------------------
### :clipboard: Mandatory Checklist

- [x] Example of a checked item (please remove when creating your Pull Request) 

- [ ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [ ] Have you discussed these changes with the project leader(s)?
- [ ] Do all variable and function names communicate what they do?
- [x] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [ ] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [x] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->
![image](https://user-images.githubusercontent.com/5196790/188288390-b720f0c6-c891-4509-9fbd-571c2c130451.png)


#### After

![image](https://user-images.githubusercontent.com/5196790/188288375-ed427f76-38c4-4de2-9b0b-c887204358cb.png)


--------------------------
### :blue_book: Glossary
- PR = Pull Request
