### PR TITLE
fix issue on frontend with updateMeeting mutation

### DIFF
--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -75,7 +75,7 @@ function Header({
     if(meetingStatus){
       updateMeeting({ 
         variables: { 
-          id: meeting.id,
+          ...meeting,
           status: meetingStatus, 
         }
       });


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
bugfix

- Describe what changes are being made
Changes to useEffect in the meeting header component

- Describe why these changes are being made
When opening a meeting the user would receive an error with meeting_start_timestamp and the frontend would break. 

- List the use cases and edge cases relevant to this PR
N/A

- Describe how errors will be handled. How will we know if this code breaks in production
Errors in console, meeting status will not update

- Describe any external libraries/dependencies added or removed in this PR
N/A

- Describe any security risks are there regarding this change
N/A

- Describe how you tested these changes
After code change, verified by creating new meeting and updating status of meeting items, agenda items, and the agenda item time. 

- Link to relevant external documentation
N/A


--------------------------
### :clipboard: Mandatory Checklist

- [ ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [x] Have you discussed these changes with the project leader(s)?
- [ ] Do all variable and function names communicate what they do?
- [ ] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [ ] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [ ] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<!--- Add after screenshots here -->


--------------------------
### :blue_book: Glossary
- PR = Pull Request
