### PR TITLE
add logic for 1st time login with Microsoft

### DIFF
--- a/backend/graphql_api/graphql/resolvers/query.js
+++ b/backend/graphql_api/graphql/resolvers/query.js
@@ -221,8 +221,13 @@ module.exports = (logger) => {
     try {
       user = await authentication.verifyMicrosoftToken(dbClient, context.token);
       if (!user.isRegistered) {
-        logger.error(`User not registered`);
-        throw new Error(`User not registered`);
+        // Create new user if first time signing in w/ Microsoft
+        user = await mutationResolver.createAccount(
+          dbClient,
+          { email_address: user.email_address },
+          context
+        );
+        return { token: user.token, email: user.email_address };
       }
       token = authentication.createJWT({ rows: [user] });
     } catch (e) {


### PR DESCRIPTION
create new account if first time logging in via Microsoft OAuth feature

### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
  - Similar to prior PR 343, this PR adds logic for handling 1st time Microsoft oAuth logins such that when a user clicks 'Sign in with Microsoft' for the first time, a new user is created in the DB (via existing graphQL mutation) with Microsoft oAuth provided details (e.g. user's Microsoft outlook email).  This behavior is closer in-line with how standard implementations of Google Sign-In (oAuth) work for most web apps.  

- Describe what changes are being made
  - See description/details above.

- Describe why these changes are being made
  - See description/details above.

- List the use cases and edge cases relevant to this PR
  - See description/details above.

- Describe how errors will be handled. How will we know if this code breaks in production
  - N/A.  Change reduces errors given application behavior prior to change was an error shown to the user that their account is not found (see 'before' illustration video below)

- Describe any external libraries/dependencies added or removed in this PR
  - N/A
  - 
- Describe any security risks are there regarding this change
  - As per description above, the intent of this PR is to reduce security risks.

- Describe how you tested these changes
  - front end functionality and server logs were tested and monitored before and after code changes to confirm expected behavior and check for any unexpected errors.
 
- Link to relevant external documentation
  - N/A



--------------------------
### :clipboard: Mandatory Checklist

- [x] Example of a checked item (please remove when creating your Pull Request) 

- [x] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [x] Have you discussed these changes with the project leader(s)?
- [x] Do all variable and function names communicate what they do?
- [x] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [x] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [x] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before

https://github.com/codeforsanjose/project-happening-atm/assets/54079796/58bf2839-9530-4967-ae0b-277f63bc2b2e



#### After

https://github.com/codeforsanjose/project-happening-atm/assets/54079796/216eeed8-16b1-421b-90e1-216f16d28db2



--------------------------
### :blue_book: Glossary
- PR = Pull Request
